### PR TITLE
RA-25 update recipestate when num of portions changes

### DIFF
--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -54,9 +54,9 @@ class RecipeFragment : Fragment() {
         viewModel.recipeUiState.observe(viewLifecycleOwner) { recipeState ->
             with(binding) {
                 tvTitleRecipeText.text = recipeState.recipe?.title
-                tvPortionsQuantity.text = "${recipeState.numOfPortions}"
+                tvPortionsQuantity.text = "${recipeState.recipe?.numOfPortions ?: 1}"
                 sbPortionsQuantity.setPadding(0, 0, 0, 0)
-                sbPortionsQuantity.progress = recipeState.numOfPortions
+                sbPortionsQuantity.progress = recipeState.recipe?.numOfPortions ?: 1
             }
 
             with(binding.ibRecipeFavoritesBtn) {
@@ -100,7 +100,7 @@ class RecipeFragment : Fragment() {
 
         recipeUiState.let {
             val ingredientsAdapter = IngredientsAdapter(
-                it.recipe?.ingredients ?: listOf(), it.numOfPortions
+                it.recipe?.ingredients ?: listOf(), it.recipe?.numOfPortions ?: 1
             )
             val methodAdapter = MethodAdapter(it.recipe?.method ?: listOf())
 
@@ -112,8 +112,7 @@ class RecipeFragment : Fragment() {
                         ) {
                             ingredientsAdapter.updateIngredients(progress)
                             tvPortionsQuantity.text = "$progress"
-                            it.numOfPortions = progress
-                            it.recipe?.numOfPortions = it.numOfPortions
+                            it.recipe?.numOfPortions = progress
                         }
 
                         override fun onStartTrackingTouch(seekBar: SeekBar?) {}

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -54,9 +54,9 @@ class RecipeFragment : Fragment() {
         viewModel.recipeUiState.observe(viewLifecycleOwner) { recipeState ->
             with(binding) {
                 tvTitleRecipeText.text = recipeState.recipe?.title
-                tvPortionsQuantity.text = "${recipeState.recipe?.numOfPortions ?: 1}"
+                tvPortionsQuantity.text = "${recipeState.numOfPortions}"
                 sbPortionsQuantity.setPadding(0, 0, 0, 0)
-                sbPortionsQuantity.progress = recipeState.recipe?.numOfPortions ?: 1
+                sbPortionsQuantity.progress = recipeState.numOfPortions
             }
 
             with(binding.ibRecipeFavoritesBtn) {
@@ -113,6 +113,7 @@ class RecipeFragment : Fragment() {
                             ingredientsAdapter.updateIngredients(progress)
                             tvPortionsQuantity.text = "$progress"
                             it.numOfPortions = progress
+                            it.recipe?.numOfPortions = it.numOfPortions
                         }
 
                         override fun onStartTrackingTouch(seekBar: SeekBar?) {}

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -111,8 +111,8 @@ class RecipeFragment : Fragment() {
                             seekBar: SeekBar?, progress: Int, fromUser: Boolean
                         ) {
                             ingredientsAdapter.updateIngredients(progress)
-                            tvPortionsQuantity.text = "$progress"
-                            it.recipe?.numOfPortions = progress
+                            viewModel.updateNumOfPortions(progress)
+                            tvPortionsQuantity.text = "${it.recipe?.numOfPortions ?: 1}"
                         }
 
                         override fun onStartTrackingTouch(seekBar: SeekBar?) {}

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
@@ -33,6 +33,8 @@ class RecipeViewModel(private val application: Application) : AndroidViewModel(a
                 it.recipe = STUB.getRecipeById(recipeId = recipeId)
                 it.isInFavorites = "$recipeId" in favoritesIdsStringSet
 
+                it.numOfPortions = it.recipe?.numOfPortions ?: 1
+
                 try {
                     val inputStream =
                         application.assets?.open(it.recipe?.imageUrl ?: "burger.png")

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
@@ -15,7 +15,6 @@ import com.example.recipeapp.model.Recipe
 
 data class RecipeUiState(
     var recipe: Recipe? = null,
-    var numOfPortions: Int = 1,
     var isInFavorites: Boolean = false,
     var recipeImage: Drawable? = null
 )
@@ -32,8 +31,6 @@ class RecipeViewModel(private val application: Application) : AndroidViewModel(a
             if (recipeId != null) {
                 it.recipe = STUB.getRecipeById(recipeId = recipeId)
                 it.isInFavorites = "$recipeId" in favoritesIdsStringSet
-
-                it.numOfPortions = it.recipe?.numOfPortions ?: 1
 
                 try {
                     val inputStream =

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
@@ -61,6 +61,10 @@ class RecipeViewModel(private val application: Application) : AndroidViewModel(a
         }
     }
 
+    fun updateNumOfPortions(numOfPortionsNew: Int) {
+        _recipeUiState.value?.recipe?.numOfPortions = numOfPortionsNew
+    }
+
     private fun getFavorites(): MutableSet<String> {
         val sharedPrefs = application.getSharedPreferences(
             SHARED_FAVORITES_IDS_FILE_NAME, Context.MODE_PRIVATE


### PR DESCRIPTION
1) **Первый коммит** ([RA-25 update recipestate when num of portions changes](https://github.com/toto-neutrino1/RecipeApp/pull/23/commits/f1146b1830a7556a8d8edceeaa29cb27e08197d8)): оставил переменную **numOfPortions** в двойном экземпляре (в классе **RecipeUiState** и в классе **Recipe**).
I) **Причина**: переменная **numOfPortions** из RecipeUiState адекватно работает в рамках одного конкретного рецепта, но при переходе к другому рецепту она работает некорректно, т.к. в ней хранится последнее значение количества порций для ПРОШЛОГО рецепта.
II) **Вариант решения**: в методе **loadRecipe()** инициализировать переменную **numOfPortions** из RecipeUiState значением **numOfPortions** из Recipe, и при изменении количества порций для конкретного рецепта обновлять одновременно обе переменные **numOfPortions**.
III) **Очевидный минус** такого подхода: по сути это получается одна и та же переменная, но в двойном экземпляре, и смысла её дублировать нет.
2) Архитектура моего класса **Recipe** такая:
I) При сдвиге ползунка в Recipe внутри списка List Ingredient обновляются значения количеств всех ингредиентов - то есть внутренность объекта конкретного Recipe обновляется при изменении количества порций.
II) Соответственно, переменная **numOfPortions** в классе **Recipe** нужна для того, чтобы знать, на сколько порций рассчитаны сохраненные в **Recipe** на данный момент количества ингредиентов.
III) Переменная **numOfPortions** в классе **Recipe** также нужна для того, чтобы при возврате к данному рецепту ползунок был в последнем сохранённом для данного рецепта положении (фича, которой изначально в задании не было, но есть в моей реализации).
IV) Поэтому удалять из **Recipe** переменную **numOfPortions** не стоит.

3) **Варианты решения**:
I) Оставить обе переменные **numOfPortions** - но по сути они дублируют друг друга и смысла в этом нет.
II) Удалить переменную **numOfPortions** из **RecipeUiState** - и использовать только переменную из класса **Recipe**.
III) Удалить переменную **numOfPortions** из **Recipe** - но тогда придётся изменить архитектуру класса **Recipe**, например, придётся сделать внутренности объекта **Recipe** неизменяемыми, храня в нём всегда данные только для одной порции; а при байндинге в RecyclerView будут отображаться данные, умноженные на количество порций (то есть отображаться будет одно, а храниться в Recipe - другое).
IV) **Минусы III подхода**: 
- при удалении numOfPortions из Recipe переменная **numOfPortions** из **RecipeUiState** всё равно при переходе к новому рецепту должна быть сброшена до 1 (при переходе между рецептами она нам не нужна);
- прогресс для конкретного рецепта будет потерян, каждый раз при выходе со страницы с рецептом и возврате к нему будет прогресс равен 1

**ИТОГ**:
a) если оставить **numOfPortions** в **RecipeUiState** и удалить в **Recipe** => моя фича с сохранением прогресса по каждому рецепту не будет работать;
b) если оставить эти переменные и в RecipeUiState, и в Recipe => они будут полностью дублировать друг друга, то есть хранить обе величины одновременно бессмысленно;
c) если оставить **numOfPortions** только в **Recipe** - прогресс по каждому рецепту будет сохраняться; причём нарушения принципов MVVM не будет, т.к. сам Recipe хранится внутри RecipeUiState, и доставать данные я буду в любом случае через RecipeUiState - я склоняюсь к этому варианту, и в следующих коммитах ([delete numOfPortions from RecipeUiState](https://github.com/toto-neutrino1/RecipeApp/pull/23/commits/bcb2391e5ba619bea75da05a245675b8e5239394]) и [add updateNumOfPortions() method in viewModel](https://github.com/toto-neutrino1/RecipeApp/pull/23/commits/b72190b917baf6e3af8ad8345e3d4c06940e3f52)) я этот вариант и реализовал