### PR TITLE
RA-27 add viewmodel with actual state for other screens

### DIFF
--- a/app/src/main/java/com/example/recipeapp/model/Recipe.kt
+++ b/app/src/main/java/com/example/recipeapp/model/Recipe.kt
@@ -11,5 +11,4 @@ data class Recipe(
     val method: List<String>,
     val imageUrl: String,
     var numOfPortions: Int = 1,
-    var isInFavorites: Boolean = false
 ) : Parcelable

--- a/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListAdapter.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListAdapter.kt
@@ -11,7 +11,7 @@ import com.example.recipeapp.databinding.ItemCategoryBinding
 import com.example.recipeapp.model.Category
 
 class CategoriesListAdapter(
-    private val dataset: List<Category>,
+    var dataset: List<Category>,
 ) : RecyclerView.Adapter<CategoriesListAdapter.CategoriesListViewHolder>() {
 
     interface OnItemClickListener {

--- a/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesListFragment.kt
@@ -6,12 +6,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import androidx.fragment.app.viewModels
 import com.example.recipeapp.R
 import com.example.recipeapp.data.ARG_CATEGORY_ID
-import com.example.recipeapp.data.STUB
 import com.example.recipeapp.databinding.FragmentListCategoriesBinding
 import com.example.recipeapp.ui.recipes.recipesList.RecipesListFragment
 
@@ -20,7 +19,7 @@ class CategoriesListFragment : Fragment() {
     private val binding
         get() = _binding ?: throw IllegalArgumentException("CategoriesListFragmentBinding is null!")
 
-    private val viewModel: CategoriesViewModel by activityViewModels()
+    private val viewModel: CategoriesViewModel by viewModels()
     private val categoriesListAdapter: CategoriesListAdapter = CategoriesListAdapter(listOf())
 
     override fun onCreateView(

--- a/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesViewModel.kt
@@ -1,0 +1,21 @@
+package com.example.recipeapp.ui.categories
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.recipeapp.data.STUB
+import com.example.recipeapp.model.Category
+
+data class CategoriesUiState(
+    var categoriesList: List<Category> = listOf()
+)
+
+class CategoriesViewModel : ViewModel() {
+    private var _categoriesUiState: MutableLiveData<CategoriesUiState> =
+        MutableLiveData(CategoriesUiState())
+    val categoriesUiState: LiveData<CategoriesUiState> = _categoriesUiState
+
+    fun loadCategories() {
+        _categoriesUiState.value?.categoriesList = STUB.getCategories()
+    }
+}

--- a/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/categories/CategoriesViewModel.kt
@@ -7,7 +7,7 @@ import com.example.recipeapp.data.STUB
 import com.example.recipeapp.model.Category
 
 data class CategoriesUiState(
-    var categoriesList: List<Category> = listOf()
+    val categoriesList: List<Category> = listOf()
 )
 
 class CategoriesViewModel : ViewModel() {
@@ -16,6 +16,7 @@ class CategoriesViewModel : ViewModel() {
     val categoriesUiState: LiveData<CategoriesUiState> = _categoriesUiState
 
     fun loadCategories() {
-        _categoriesUiState.value?.categoriesList = STUB.getCategories()
+        _categoriesUiState.value =
+            _categoriesUiState.value?.copy(categoriesList = STUB.getCategories())
     }
 }

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesFragment.kt
@@ -6,9 +6,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import androidx.fragment.app.viewModels
 import com.example.recipeapp.R
 import com.example.recipeapp.data.ARG_RECIPE_ID
 import com.example.recipeapp.databinding.FragmentFavoritesBinding
@@ -20,7 +20,7 @@ class FavoritesFragment : Fragment() {
     private val binding
         get() = _binding ?: throw IllegalArgumentException("FragmentFavoritesBinding is null!")
 
-    private val viewModel: FavoritesViewModel by activityViewModels()
+    private val viewModel: FavoritesViewModel by viewModels()
     private val recipesListAdapter = RecipesListAdapter(listOf())
 
     override fun onCreateView(

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -11,7 +11,7 @@ import com.example.recipeapp.data.STUB
 import com.example.recipeapp.model.Recipe
 
 data class FavoritesUiState(
-    var recipesList: List<Recipe> = listOf()
+    val recipesList: List<Recipe> = listOf()
 )
 
 class FavoritesViewModel(private val application: Application) : AndroidViewModel(application) {
@@ -20,7 +20,8 @@ class FavoritesViewModel(private val application: Application) : AndroidViewMode
     val favoritesUiState: LiveData<FavoritesUiState> = _favoritesUiState
 
     fun loadFavorites() {
-        _favoritesUiState.value?.recipesList = STUB.getRecipesByIds(getFavoritesIds())
+        _favoritesUiState.value =
+            _favoritesUiState.value?.copy(recipesList = STUB.getRecipesByIds(getFavoritesIds()))
     }
 
     private fun getFavoritesIds(): Set<Int> {

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/favorites/FavoritesViewModel.kt
@@ -1,0 +1,35 @@
+package com.example.recipeapp.ui.recipes.favorites
+
+import android.app.Application
+import android.content.Context
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.example.recipeapp.data.SHARED_FAVORITES_IDS_FILE_NAME
+import com.example.recipeapp.data.SHARED_FAVORITES_IDS_KEY
+import com.example.recipeapp.data.STUB
+import com.example.recipeapp.model.Recipe
+
+data class FavoritesUiState(
+    var recipesList: List<Recipe> = listOf()
+)
+
+class FavoritesViewModel(private val application: Application) : AndroidViewModel(application) {
+    private var _favoritesUiState: MutableLiveData<FavoritesUiState> =
+        MutableLiveData(FavoritesUiState())
+    val favoritesUiState: LiveData<FavoritesUiState> = _favoritesUiState
+
+    fun loadFavorites() {
+        _favoritesUiState.value?.recipesList = STUB.getRecipesByIds(getFavoritesIds())
+    }
+
+    private fun getFavoritesIds(): Set<Int> {
+        val sharedPrefs = application.getSharedPreferences(
+            SHARED_FAVORITES_IDS_FILE_NAME, Context.MODE_PRIVATE
+        )
+        val setOfFavoritesIds =
+            sharedPrefs?.getStringSet(SHARED_FAVORITES_IDS_KEY, setOf()) ?: setOf()
+
+        return setOfFavoritesIds.map { it.toInt() }.toSet()
+    }
+}

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/IngredientsAdapter.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/IngredientsAdapter.kt
@@ -5,16 +5,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.example.recipeapp.R
-import com.example.recipeapp.data.NUM_OF_INGREDIENT_MANTIS
 import com.example.recipeapp.databinding.ItemIngredientBinding
 import com.example.recipeapp.model.Ingredient
-import java.math.BigDecimal
-import java.math.RoundingMode
-import java.util.Locale
 
 class IngredientsAdapter(
     var dataset: List<Ingredient>,
-    var quantity: Int = 1
 ) : RecyclerView.Adapter<IngredientsAdapter.IngredientsViewHolder>() {
 
     class IngredientsViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -38,29 +33,5 @@ class IngredientsAdapter(
 
     override fun getItemCount() = dataset.size
 
-    fun updateIngredients(progress: Int) {
-        dataset.forEach {
-            val componentQuantity = it.quantity.toDouble() * progress / quantity
-
-            it.quantity =
-                if (isInteger(componentQuantity)) {
-                    "${componentQuantity.toInt()}"
-                } else {
-                    "%.${NUM_OF_INGREDIENT_MANTIS}f".format(locale = Locale.US, componentQuantity)
-                }
-        }
-
-        quantity = progress
-
-        notifyDataSetChanged()
-    }
+    fun notifyUpdateIngredients() = notifyDataSetChanged()
 }
-
-private fun isInteger(num: Double) =
-    convertToNumWithNeededAccuracy(num.toInt().toDouble(), NUM_OF_INGREDIENT_MANTIS) ==
-            convertToNumWithNeededAccuracy(num, NUM_OF_INGREDIENT_MANTIS)
-
-private fun convertToNumWithNeededAccuracy(num: Double, accuracy: Int) =
-    BigDecimal("$num")
-        .setScale(accuracy, RoundingMode.HALF_UP)
-        .stripTrailingZeros().toPlainString()

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -25,6 +25,9 @@ class RecipeFragment : Fragment() {
     private val ingredientsAdapter: IngredientsAdapter = IngredientsAdapter(listOf())
     private val methodAdapter: MethodAdapter = MethodAdapter(listOf())
 
+    private var isNewFragment: Boolean = true
+    private var isClickedOnFavorites: Boolean = false
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -56,45 +59,60 @@ class RecipeFragment : Fragment() {
 
     private fun initUI() {
         viewModel.recipeUiState.observe(viewLifecycleOwner) { recipeState ->
-            with(binding) {
-                tvTitleRecipeText.text = recipeState.recipe?.title
-                tvPortionsQuantity.text = "${recipeState.recipe?.numOfPortions ?: 1}"
-                sbPortionsQuantity.setPadding(0, 0, 0, 0)
-                sbPortionsQuantity.progress = recipeState.recipe?.numOfPortions ?: 1
-            }
+            if (isNewFragment) {
+                isNewFragment = false
+                with(binding) {
+                    tvTitleRecipeText.text = recipeState.recipe?.title
+                    tvPortionsQuantity.text = "${recipeState.recipe?.numOfPortions ?: 1}"
+                    sbPortionsQuantity.setPadding(0, 0, 0, 0)
+                    sbPortionsQuantity.progress = recipeState.recipe?.numOfPortions ?: 1
+                }
 
-            with(binding.ibRecipeFavoritesBtn) {
-                setImageDrawable(
-                    ResourcesCompat.getDrawable(
-                        resources,
-                        if (recipeState.recipe != null && recipeState.isInFavorites) {
-                            R.drawable.ic_heart
-                        } else R.drawable.ic_heart_empty,
-                        null
+                with(binding.ibRecipeFavoritesBtn) {
+                    setImageDrawable(
+                        ResourcesCompat.getDrawable(
+                            resources,
+                            if (recipeState.recipe != null && recipeState.isInFavorites) {
+                                R.drawable.ic_heart
+                            } else R.drawable.ic_heart_empty,
+                            null
+                        )
                     )
-                )
 
-                setOnClickListener {
-                    viewModel.onFavoritesClicked()
-                    if (recipeState.isInFavorites) {
-                        setImageDrawable(
-                            ResourcesCompat.getDrawable(resources, R.drawable.ic_heart, null)
-                        )
-                    } else {
-                        setImageDrawable(
-                            ResourcesCompat.getDrawable(resources, R.drawable.ic_heart_empty, null)
-                        )
+                    setOnClickListener {
+                        isClickedOnFavorites = true
+                        viewModel.onFavoritesClicked()
                     }
                 }
-            }
 
-            with(binding.ivTitleRecipeImage) {
-                setImageDrawable(recipeState.recipeImage)
-                contentDescription =
-                    "${context?.getString(R.string.cont_descr_iv_recipe)} ${recipeState.recipe?.title}"
-            }
+                with(binding.ivTitleRecipeImage) {
+                    setImageDrawable(recipeState.recipeImage)
+                    contentDescription =
+                        "${context?.getString(R.string.cont_descr_iv_recipe)} ${recipeState.recipe?.title}"
+                }
 
-            initRecyclers(recipeState)
+                initRecyclers(recipeState)
+            } else {
+                with(binding) {
+                    tvPortionsQuantity.text = "${recipeState.recipe?.numOfPortions ?: 1}"
+                    sbPortionsQuantity.progress = recipeState.recipe?.numOfPortions ?: 1
+                }
+
+                if (isClickedOnFavorites) {
+                    isClickedOnFavorites = false
+                    binding.ibRecipeFavoritesBtn.setImageDrawable(
+                        ResourcesCompat.getDrawable(
+                            resources,
+                            if (recipeState.recipe != null && recipeState.isInFavorites) {
+                                R.drawable.ic_heart
+                            } else R.drawable.ic_heart_empty,
+                            null
+                        )
+                    )
+                }
+
+                ingredientsAdapter.notifyUpdateIngredients()
+            }
         }
     }
 
@@ -111,8 +129,6 @@ class RecipeFragment : Fragment() {
                 sbPortionsQuantity.setOnSeekBarChangeListener(
                     PortionSeekBarListener { progress ->
                         viewModel.updateIngredientsAndNumOfPortions(progress)
-                        ingredientsAdapter.notifyUpdateIngredients()
-                        tvPortionsQuantity.text = "${it.recipe?.numOfPortions ?: 1}"
                     }
                 )
 

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -22,7 +22,7 @@ class RecipeFragment : Fragment() {
     private var recipeId: Int? = null
     private val viewModel: RecipeViewModel by activityViewModels()
 
-    private val ingredientsAdapter: IngredientsAdapter = IngredientsAdapter(listOf(), 1)
+    private val ingredientsAdapter: IngredientsAdapter = IngredientsAdapter(listOf())
     private val methodAdapter: MethodAdapter = MethodAdapter(listOf())
 
     override fun onCreateView(
@@ -103,18 +103,15 @@ class RecipeFragment : Fragment() {
             ResourcesCompat.getDrawable(resources, R.drawable.divider_item_decoration, null)
 
         recipeUiState.let {
-            with(ingredientsAdapter) {
-                dataset = it.recipe?.ingredients ?: listOf()
-                quantity = it.recipe?.numOfPortions ?: 1
-            }
+            ingredientsAdapter.dataset = it.recipe?.ingredients ?: listOf()
 
             methodAdapter.dataset = it.recipe?.method ?: listOf()
 
             with(binding) {
                 sbPortionsQuantity.setOnSeekBarChangeListener(
                     PortionSeekBarListener { progress ->
-                        ingredientsAdapter.updateIngredients(progress)
-                        viewModel.updateNumOfPortions(progress)
+                        viewModel.updateIngredientsAndNumOfPortions(progress)
+                        ingredientsAdapter.notifyUpdateIngredients()
                         tvPortionsQuantity.text = "${it.recipe?.numOfPortions ?: 1}"
                     }
                 )

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeFragment.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import android.widget.SeekBar
 import android.widget.SeekBar.OnSeekBarChangeListener
 import androidx.core.content.res.ResourcesCompat
-import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import com.example.recipeapp.R
 import com.example.recipeapp.data.ARG_RECIPE_ID
 import com.example.recipeapp.databinding.FragmentRecipeBinding
@@ -20,7 +20,7 @@ class RecipeFragment : Fragment() {
         get() = _binding ?: throw IllegalArgumentException("FragmentRecipeBinding is null!")
 
     private var recipeId: Int? = null
-    private val viewModel: RecipeViewModel by activityViewModels()
+    private val viewModel: RecipeViewModel by viewModels()
 
     private val ingredientsAdapter: IngredientsAdapter = IngredientsAdapter(listOf())
     private val methodAdapter: MethodAdapter = MethodAdapter(listOf())

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipe/RecipeViewModel.kt
@@ -51,18 +51,19 @@ class RecipeViewModel(private val application: Application) : AndroidViewModel(a
     }
 
     fun onFavoritesClicked() {
+        val newFavoritesFlag: Boolean
         with(_recipeUiState.value) {
-            if (this?.recipe != null && this.isInFavorites) {
+            newFavoritesFlag = if (this?.recipe != null && this.isInFavorites) {
                 favoritesIdsStringSet.remove("${this.recipe.id}")
-                _recipeUiState.value = _recipeUiState.value?.copy(isInFavorites = false)
+                false
             } else {
                 favoritesIdsStringSet.add("${this?.recipe?.id}")
-                _recipeUiState.value = _recipeUiState.value?.copy(isInFavorites = true)
+                true
             }
             saveFavorites(favoritesIdsStringSet)
         }
 
-        notifyObserver()
+        _recipeUiState.postValue(recipeUiState.value?.copy(isInFavorites = newFavoritesFlag))
     }
 
     fun updateIngredientsAndNumOfPortions(progress: Int) {
@@ -84,10 +85,8 @@ class RecipeViewModel(private val application: Application) : AndroidViewModel(a
             recipe.numOfPortions = progress
         }
 
-        notifyObserver()
+        _recipeUiState.postValue(recipeUiState.value)
     }
-
-    private fun notifyObserver() = _recipeUiState.postValue(recipeUiState.value)
 
     private fun getFavorites(): MutableSet<String> {
         val sharedPrefs = application.getSharedPreferences(

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipeListViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipeListViewModel.kt
@@ -1,0 +1,42 @@
+package com.example.recipeapp.ui.recipes.recipesList
+
+import android.app.Application
+import android.graphics.drawable.Drawable
+import android.util.Log
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.example.recipeapp.R
+import com.example.recipeapp.data.STUB
+import com.example.recipeapp.model.Category
+import com.example.recipeapp.model.Recipe
+
+data class RecipeListUiState(
+    var category: Category? = null,
+    var recipesList: List<Recipe> = listOf(),
+    var recipeListTitleImage: Drawable? = null
+)
+
+class RecipeListViewModel(private val application: Application) : AndroidViewModel(application) {
+    private var _recipeListUiState: MutableLiveData<RecipeListUiState> =
+        MutableLiveData(RecipeListUiState())
+    val recipeListUiState: LiveData<RecipeListUiState> = _recipeListUiState
+
+    fun loadRecipesList(categoryId: Int?) {
+        _recipeListUiState.value?.let {
+            it.category = STUB.getCategories().find { category -> category.id == categoryId }
+            it.recipesList = STUB.getRecipesByCategoryId(categoryId ?: 0)
+
+            try {
+                val inputStream =
+                    application.assets?.open(it.category?.imageUrl ?: "burger.png")
+                it.recipeListTitleImage = Drawable.createFromStream(inputStream, null)
+            } catch (e: Exception) {
+                Log.e(
+                    "${application.getString(R.string.asset_error)}",
+                    "${e.printStackTrace()}"
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipeListViewModel.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipeListViewModel.kt
@@ -12,9 +12,9 @@ import com.example.recipeapp.model.Category
 import com.example.recipeapp.model.Recipe
 
 data class RecipeListUiState(
-    var category: Category? = null,
-    var recipesList: List<Recipe> = listOf(),
-    var recipeListTitleImage: Drawable? = null
+    val category: Category? = null,
+    val recipesList: List<Recipe> = listOf(),
+    val recipeListTitleImage: Drawable? = null
 )
 
 class RecipeListViewModel(private val application: Application) : AndroidViewModel(application) {
@@ -23,20 +23,22 @@ class RecipeListViewModel(private val application: Application) : AndroidViewMod
     val recipeListUiState: LiveData<RecipeListUiState> = _recipeListUiState
 
     fun loadRecipesList(categoryId: Int?) {
-        _recipeListUiState.value?.let {
-            it.category = STUB.getCategories().find { category -> category.id == categoryId }
-            it.recipesList = STUB.getRecipesByCategoryId(categoryId ?: 0)
+        try {
+            val inputStream = application.assets?.open(
+                _recipeListUiState.value?.category?.imageUrl ?: "burger.png"
+            )
 
-            try {
-                val inputStream =
-                    application.assets?.open(it.category?.imageUrl ?: "burger.png")
-                it.recipeListTitleImage = Drawable.createFromStream(inputStream, null)
-            } catch (e: Exception) {
-                Log.e(
-                    "${application.getString(R.string.asset_error)}",
-                    "${e.printStackTrace()}"
+            _recipeListUiState.value =
+                _recipeListUiState.value?.copy(
+                    category = STUB.getCategories().find { category -> category.id == categoryId },
+                    recipesList = STUB.getRecipesByCategoryId(categoryId ?: 0),
+                    recipeListTitleImage = Drawable.createFromStream(inputStream, null)
                 )
-            }
+        } catch (e: Exception) {
+            Log.e(
+                "${application.getString(R.string.asset_error)}",
+                "${e.printStackTrace()}"
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipesListAdapter.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipesListAdapter.kt
@@ -11,7 +11,7 @@ import com.example.recipeapp.databinding.ItemRecipeBinding
 import com.example.recipeapp.model.Recipe
 
 class RecipesListAdapter(
-    private val dataset: List<Recipe>,
+    var dataset: List<Recipe>,
 ) : RecyclerView.Adapter<RecipesListAdapter.RecipesListViewHolder>() {
 
     interface OnItemClickListener {

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipesListFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipesListFragment.kt
@@ -6,9 +6,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
-import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import androidx.fragment.app.viewModels
 import com.example.recipeapp.R
 import com.example.recipeapp.data.ARG_CATEGORY_ID
 import com.example.recipeapp.data.ARG_RECIPE_ID
@@ -22,7 +22,7 @@ class RecipesListFragment : Fragment() {
         get() = _binding ?: throw IllegalArgumentException("FragmentListRecipesBinding is null!")
 
     private var categoryId: Int? = null
-    private val viewModel: RecipeListViewModel by activityViewModels()
+    private val viewModel: RecipeListViewModel by viewModels()
 
     private val recipesListAdapter = RecipesListAdapter(listOf())
 

--- a/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipesListFragment.kt
+++ b/app/src/main/java/com/example/recipeapp/ui/recipes/recipesList/RecipesListFragment.kt
@@ -1,22 +1,17 @@
 package com.example.recipeapp.ui.recipes.recipesList
 
-import android.graphics.drawable.Drawable
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
 import com.example.recipeapp.R
 import com.example.recipeapp.data.ARG_CATEGORY_ID
-import com.example.recipeapp.data.ARG_CATEGORY_IMAGE_URL
-import com.example.recipeapp.data.ARG_CATEGORY_NAME
-import com.example.recipeapp.data.ARG_RECIPE
 import com.example.recipeapp.data.ARG_RECIPE_ID
-import com.example.recipeapp.data.STUB
 import com.example.recipeapp.databinding.FragmentListRecipesBinding
 import com.example.recipeapp.ui.recipes.recipe.RecipeFragment
 
@@ -27,8 +22,9 @@ class RecipesListFragment : Fragment() {
         get() = _binding ?: throw IllegalArgumentException("FragmentListRecipesBinding is null!")
 
     private var categoryId: Int? = null
-    private var categoryName: String? = null
-    private var categoryImageUrl: String? = null
+    private val viewModel: RecipeListViewModel by activityViewModels()
+
+    private val recipesListAdapter = RecipesListAdapter(listOf())
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -42,8 +38,7 @@ class RecipesListFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initInputBundleData()
-        setInitScreenContent()
-        initRecycler()
+        initUI()
     }
 
     override fun onDestroyView() {
@@ -54,35 +49,29 @@ class RecipesListFragment : Fragment() {
     private fun initInputBundleData() {
         arguments?.let {
             categoryId = it.getInt(ARG_CATEGORY_ID)
-            categoryName = it.getString(ARG_CATEGORY_NAME)
-            categoryImageUrl = it.getString(ARG_CATEGORY_IMAGE_URL)
         }
+
+        viewModel.loadRecipesList(categoryId)
     }
 
-    private fun setInitScreenContent() {
-        binding.tvTitleListRecipesText.text =
-            categoryName ?: context?.getString(R.string.title_burgers)
+    private fun initUI() {
+        viewModel.recipeListUiState.observe(viewLifecycleOwner) { recipeListState ->
+            binding.tvTitleListRecipesText.text = recipeListState.category?.title
 
-        with(binding.ivTitleListRecipesImage) {
-            try {
-                val inputStream = context?.assets?.open(categoryImageUrl ?: "burger.png")
-                val drawable = Drawable.createFromStream(inputStream, null)
-                setImageDrawable(drawable)
-            } catch (e: Exception) {
-                Log.e(
-                    "${context?.getString(R.string.asset_error)}",
-                    "${e.printStackTrace()}"
-                )
+            with(binding.ivTitleListRecipesImage) {
+                setImageDrawable(recipeListState.recipeListTitleImage)
+
+                contentDescription =
+                    "${context?.getString(R.string.cont_descr_iv_list_recipes)} " +
+                            "${recipeListState.category?.title}"
             }
 
-            contentDescription =
-                "${context?.getString(R.string.cont_descr_iv_list_recipes)} $categoryName"
+            initRecycler(recipeListState)
         }
     }
 
-    private fun initRecycler() {
-        val recipesListAdapter =
-            RecipesListAdapter(dataset = STUB.getRecipesByCategoryId(categoryId ?: 0))
+    private fun initRecycler(recipeListState: RecipeListUiState) {
+        recipesListAdapter.dataset = recipeListState.recipesList
 
         recipesListAdapter.setOnItemClickListener(
             object : RecipesListAdapter.OnItemClickListener {


### PR DESCRIPTION
В **RecipeViewModel** перенёс из **IngredientsAdapter** часть кода, которая меняет исходные данные, чтобы это соответствовало подходу UDF.
В остальных адаптерах ничего переносить не стал, т.к. в них только указывается, где и какие данные нужно показать, сами данные при этом нигде не меняются.